### PR TITLE
Workaround for issue #6. Now the code checks if DDSCAT file is from 6…

### DIFF
--- a/apps/3d_structures_multithreaded/shapeIOtextParsers2.cpp
+++ b/apps/3d_structures_multithreaded/shapeIOtextParsers2.cpp
@@ -424,7 +424,12 @@ namespace icedb {
 						//np = macros::m_atoi<size_t>(&(lin.data()[posa]), len);
 					}
 					break;
-					case 6: // Junk line
+					case 6: // In case of DDSCAT6 this is the first valid dipole
+					        // This method is not super robust: what if line 7 contains just numbers but not a dipole coordinate
+					{
+					    bool isNotHeaderLine = (lin.find_first_not_of(" \t-+0123456789") == std::string::npos);
+					    if (isNotHeaderLine) pend = pstart; // I assume not header line implies a dipole thus I put back the buffer to the line start
+					}
 					default:
 						break;
 					case 2: // a1

--- a/apps/3d_structures_singlefile/shapeIOtextParsers2.cpp
+++ b/apps/3d_structures_singlefile/shapeIOtextParsers2.cpp
@@ -424,7 +424,12 @@ namespace icedb {
 						//np = macros::m_atoi<size_t>(&(lin.data()[posa]), len);
 					}
 					break;
-					case 6: // Junk line
+					case 6: // In case of DDSCAT6 this is the first valid dipole
+					        // This method is not super robust: what if line 7 contains just numbers but not a dipole coordinate
+					{
+					    bool isNotHeaderLine = (lin.find_first_not_of(" \t-+0123456789") == std::string::npos);
+					    if (isNotHeaderLine) pend = pstart; // I assume not header line implies a dipole thus I put back the buffer to the line start
+					}
 					default:
 						break;
 					case 2: // a1

--- a/apps/3d_structures_singlethreaded/shapeIOtextParsers2.cpp
+++ b/apps/3d_structures_singlethreaded/shapeIOtextParsers2.cpp
@@ -428,19 +428,10 @@ namespace icedb {
 					}
 					break;
 					case 6: // In case of DDSCAT6 this is the first valid dipole
-					        // This method is not super robust, but if line 7 matches the pattern of 7 integers it should be recognized as a dipole
+					        // This method is not super robust: what if line 7 contains just numbers but not a dipole coordinate
 					{
-					    std::istringstream iss(lin);
-					    size_t number_of_words = 0;
-					    bool isInteger=true;
-					    while (iss and isInteger)
-					    {
-					        std::string word;
-					        iss>>word;
-					        number_of_words++;
-					        isInteger = (word.find_first_not_of( "-+0123456789" ) == string::npos);
-					    }
-					    if (number_of_words == 8) pend = pstart; // If I count seven integers I put back the buffer to the line start
+					    bool isNotHeaderLine = (lin.find_first_not_of(" \t-+0123456789") == std::string::npos);
+					    if (isNotHeaderLine) pend = pstart; // I assume not header line implies a dipole thus I put back the buffer to the line start
 					}
 					default:
 						break;

--- a/apps/3d_structures_singlethreaded/shapeIOtextParsers2.cpp
+++ b/apps/3d_structures_singlethreaded/shapeIOtextParsers2.cpp
@@ -6,6 +6,9 @@
 #include <fstream>
 #include <cmath>
 
+#include<cerrno>
+#include<cstdlib>
+
 #include <icedb/fs_backend.hpp>
 #include <boost/lexical_cast.hpp>
 //#include <boost/iostreams/copy.hpp>
@@ -424,7 +427,21 @@ namespace icedb {
 						//np = macros::m_atoi<size_t>(&(lin.data()[posa]), len);
 					}
 					break;
-					case 6: // Junk line
+					case 6: // In case of DDSCAT6 this is the first valid dipole
+					        // This method is not super robust, but if line 7 matches the pattern of 7 integers it should be recognized as a dipole
+					{
+					    std::istringstream iss(lin);
+					    size_t number_of_words = 0;
+					    bool isInteger=true;
+					    while (iss and isInteger)
+					    {
+					        std::string word;
+					        iss>>word;
+					        number_of_words++;
+					        isInteger = (word.find_first_not_of( "-+0123456789" ) == string::npos);
+					    }
+					    if (number_of_words == 8) pend = pstart; // If I count seven integers I put back the buffer to the line start
+					}
 					default:
 						break;
 					case 2: // a1


### PR DESCRIPTION
… or 7 version by looking at line 7. Not perfectly robust, line 7 is ignored by DDA codes and might contain 7 integers even if that is not a dipole description.

This pull request try to address issue #6 which might help for the inclusion of older scattering databases

I have modified only the single-threaded parser we might want to push modifications also to the others