### PR TITLE
Fixing #12.

### DIFF
--- a/apps/3d_structures_multithreaded/shapeIOtextParsers2.cpp
+++ b/apps/3d_structures_multithreaded/shapeIOtextParsers2.cpp
@@ -21,18 +21,23 @@ namespace icedb {
 				max_element = 0;
 				size_t curout = 0;
 				// Accepts numbers of the form: [0-9]*
-				// No negatives, exponents or decimals.
+				// Handles negatives, No exponents or decimals.
 
 				float numerator = 0;
 				assert(in);
 				const char* end = in + inlen;
 				bool readnums = false;
+				bool negative = false;
 				for (const char* cur = in; (cur <= end) && (curout < outlen); ++cur) {
-					if ((*cur <= '9') && (*cur >= '0')) {
+				    if (*cur == '-') {
+				        negative = true;
+				    } else if ((*cur <= '9') && (*cur >= '0')) {
 						numerator *= 10;
 						numerator += (*cur - '0');
 						readnums = true;
 					} else if(readnums){
+					    if (negative) numerator = -numerator;
+					    negative = false;
 						out[curout] = numerator;
 						if (numerator > max_element) max_element = numerator;
 						curout++;

--- a/apps/3d_structures_singlefile/shapeIOtextParsers2.cpp
+++ b/apps/3d_structures_singlefile/shapeIOtextParsers2.cpp
@@ -21,18 +21,23 @@ namespace icedb {
 				max_element = 0;
 				size_t curout = 0;
 				// Accepts numbers of the form: [0-9]*
-				// No negatives, exponents or decimals.
+				// Handles negatives, No exponents or decimals.
 
 				float numerator = 0;
 				assert(in);
 				const char* end = in + inlen;
 				bool readnums = false;
+				bool negative = false;
 				for (const char* cur = in; (cur <= end) && (curout < outlen); ++cur) {
-					if ((*cur <= '9') && (*cur >= '0')) {
+				    if (*cur == '-') {
+				        negative = true;
+				    } else if ((*cur <= '9') && (*cur >= '0')) {
 						numerator *= 10;
 						numerator += (*cur - '0');
 						readnums = true;
 					} else if(readnums){
+					    if (negative) numerator = -numerator;
+					    negative = false;
 						out[curout] = numerator;
 						if (numerator > max_element) max_element = numerator;
 						curout++;
@@ -42,7 +47,6 @@ namespace icedb {
 				}
 				return curout;
 			}
-
 
 			size_t array_to_floats(
 				const char* in, const size_t inlen, float* out, const size_t outlen)

--- a/apps/3d_structures_singlethreaded/shapeIOtextParsers2.cpp
+++ b/apps/3d_structures_singlethreaded/shapeIOtextParsers2.cpp
@@ -24,18 +24,23 @@ namespace icedb {
 				max_element = 0;
 				size_t curout = 0;
 				// Accepts numbers of the form: [0-9]*
-				// No negatives, exponents or decimals.
+				// Handles negatives, No exponents or decimals.
 
 				float numerator = 0;
 				assert(in);
 				const char* end = in + inlen;
 				bool readnums = false;
+				bool negative = false;
 				for (const char* cur = in; (cur <= end) && (curout < outlen); ++cur) {
-					if ((*cur <= '9') && (*cur >= '0')) {
+				    if (*cur == '-') {
+				        negative = true;
+				    } else if ((*cur <= '9') && (*cur >= '0')) {
 						numerator *= 10;
 						numerator += (*cur - '0');
 						readnums = true;
 					} else if(readnums){
+					    if (negative) numerator = -numerator;
+					    negative = false;
 						out[curout] = numerator;
 						if (numerator > max_element) max_element = numerator;
 						curout++;

--- a/lib/icedb/shape.hpp
+++ b/lib/icedb/shape.hpp
@@ -39,7 +39,7 @@ namespace icedb {
 			/// Are the particle_scattering_element_coordinates integers?
 			/// This allows for optimization when writing.
 			/// If they are integers, then particle_scattering_element_coordinates_ints is written instead.
-			uint64_t particle_scattering_element_coordinates_are_integral = 0;
+			uint8_t particle_scattering_element_coordinates_are_integral = 0;
 			
 
 			// The ATTRIBUTES
@@ -59,7 +59,7 @@ namespace icedb {
 		/// Structure containing a list of all of the common optional data for creating a new shape in the database.
 		struct NewShapeCommonOptionalProperties {
 			/// DIMENSION: The id number for each scattering element. Single dimension.
-			gsl::span<const uint64_t> particle_scattering_element_number;
+			gsl::span<const int64_t> particle_scattering_element_number;
 			/// DIMENSION: The id number of each particle's constituent. Single dimension.
 			gsl::span<const uint8_t> particle_constituent_number;
 

--- a/lib/icedb/shape.hpp
+++ b/lib/icedb/shape.hpp
@@ -59,7 +59,7 @@ namespace icedb {
 		/// Structure containing a list of all of the common optional data for creating a new shape in the database.
 		struct NewShapeCommonOptionalProperties {
 			/// DIMENSION: The id number for each scattering element. Single dimension.
-			gsl::span<const int64_t> particle_scattering_element_number;
+			gsl::span<const uint64_t> particle_scattering_element_number;
 			/// DIMENSION: The id number of each particle's constituent. Single dimension.
 			gsl::span<const uint8_t> particle_constituent_number;
 

--- a/lib/src/Shapes.cpp
+++ b/lib/src/Shapes.cpp
@@ -220,7 +220,7 @@ namespace icedb {
 		}
 
 		Shape::Shape_Type Shape::openShape(Groups::Group &owner, const std::string &name) {
-			assert(owner.doesGroupExist(name));
+			Expects(owner.doesGroupExist(name));
 			return openShape(owner.openGroup(name)->getHDF5Group());
 		}
 		
@@ -270,21 +270,21 @@ namespace icedb {
 
 			std::unique_ptr<icedb::Tables::Table> tblPSEN;
 			{
-				tblPSEN = res->createTable<uint64_t>("particle_scattering_element_number",
+				tblPSEN = res->createTable<int64_t>("particle_scattering_element_number",
 				{ static_cast<size_t>(required->number_of_particle_scattering_elements) });
 				bool added = false;
 				if (optional) {
 					if (!optional->particle_scattering_element_number.empty()) {
-						tblPSEN->writeAll<uint64_t>(optional->particle_scattering_element_number);
+						tblPSEN->writeAll(optional->particle_scattering_element_number);
 						added = true;
 					}
 				}
 				if (!added) {
 					// Create "dummy" element numbers and write.
-					std::vector<uint64_t> dummyPSENs(required->number_of_particle_scattering_elements);
+					std::vector<int64_t> dummyPSENs(required->number_of_particle_scattering_elements);
 					for (size_t i = 0; i < required->number_of_particle_scattering_elements; ++i)
 						dummyPSENs[i] = i + 1;
-					tblPSEN->writeAll<uint64_t>(dummyPSENs);
+					tblPSEN->writeAll(dummyPSENs);
 				}
 				// NOTE: The HDF5 dimension scale specification explicitly allows for dimensions to not have assigned values.
 				// However, netCDF should have these values.
@@ -329,47 +329,16 @@ namespace icedb {
 			// available integer storage type.
 			/// \todo With HDFforHumans, be sure to add support for using minimal-sized types.
 			/// \todo Auto-detect if we are using integral scattering element coordinates.
-			bool considerInts = (required->particle_scattering_element_coordinates_are_integral) ? true : false;
-			bool useUint16s = false, useUint8s = false;
-			if (considerInts) {
-				// This minmax check is very slow.....
-				//const auto bounds = std::minmax_element(required->particle_scattering_element_coordinates.cbegin(), required->particle_scattering_element_coordinates.cend());
-				//if (*(bounds.first) > 0) {
-				//	if (*(bounds.second) < UINT8_MAX - 2) useUint8s = true;
-				//	else if (*(bounds.second) < UINT16_MAX - 2) useUint16s = true;
-				//}
-				float mx = -1;
-				if (optional) {
-					if (optional->hint_max_scattering_element_dimension > 0) {
-						mx = optional->hint_max_scattering_element_dimension > 0;
-					}
-				}
-				if (mx < 0) {
-					auto me = std::max_element(required->particle_scattering_element_coordinates.cbegin(), required->particle_scattering_element_coordinates.cend());
-					mx = *me;
-				}
-				if (mx < UINT8_MAX - 2) useUint8s = true;
-					else if (mx < UINT16_MAX - 2) useUint16s = true;
-			}
+			bool useInts = (required->particle_scattering_element_coordinates_are_integral) ? true : false;
 			
-			if (useUint8s) {
-				std::vector<uint8_t> crds_ints(required->number_of_particle_scattering_elements * 3);
+			if (useInts) {
+				std::vector<int32_t> crds_ints(required->number_of_particle_scattering_elements*3);
 				for (size_t i = 0; i < crds_ints.size(); ++i) {
-					crds_ints[i] = static_cast<uint8_t>(required->particle_scattering_element_coordinates[i]);
+					// Narrow cast will check that the representation remains the same.
+					// If the values change, then the cast will fail and the program will abort.
+					crds_ints[i] = gsl::narrow_cast<int32_t>(required->particle_scattering_element_coordinates[i]);
 				}
-				auto tblPSEC = res->createTable<uint8_t>(
-					"particle_scattering_element_coordinates",
-					{ static_cast<size_t>(required->number_of_particle_scattering_elements), 3 },
-					crds_ints, &chunks);
-				if (tblPSEN) tblPSEC->attachDimensionScale(0, tblPSEN.get());
-				if (tblXYZ) tblPSEC->attachDimensionScale(1, tblXYZ.get());
-			}
-			else if (useUint16s) {
-				std::vector<uint16_t> crds_ints(required->number_of_particle_scattering_elements*3);
-				for (size_t i = 0; i < crds_ints.size(); ++i) {
-					crds_ints[i] = static_cast<uint16_t>(required->particle_scattering_element_coordinates[i]);
-				}
-				auto tblPSEC = res->createTable<uint16_t>(
+				auto tblPSEC = res->createTable<int32_t>(
 					"particle_scattering_element_coordinates",
 					{ static_cast<size_t>(required->number_of_particle_scattering_elements), 3 },
 					crds_ints, &chunks);
@@ -383,12 +352,9 @@ namespace icedb {
 				if (tblXYZ) tblPSEC->attachDimensionScale(1, tblXYZ.get());
 			}
 
-
 			if (optional) {
 
 				// TODO: if (optional->particle_constituent_name.size()) {}
-
-
 				if (optional->particle_constituent_single_name.size()) {
 					res->writeAttribute<std::string>("particle_single_constituent_name",
 						{ 1 }, { optional->particle_constituent_single_name });

--- a/lib/src/Shapes.cpp
+++ b/lib/src/Shapes.cpp
@@ -114,7 +114,6 @@ namespace icedb {
 				}
 			}
 			
-			
 			if (this->particle_scattering_element_radius.size()) {
 				if (this->particle_scattering_element_radius.size() != required->number_of_particle_scattering_elements) {
 					good = false;
@@ -131,11 +130,13 @@ namespace icedb {
 				if (out) (*out) << "particle_constituent_single_name is a valid attribute only when a single non-ice constituent exists."
 					<< std::endl;
 			}
+
 			if (particle_constituent_single_name.size() && this->particle_constituent_name.size()) {
 				good = false;
 				if (out) (*out) << "particle_constituent_single_name and particle_constituent_name are mutually exclusive."
 					<< std::endl;
 			}
+
 			if (this->particle_constituent_name.size()) {
 				if (this->particle_constituent_name.size() != required->number_of_particle_constituents) {
 					good = false;
@@ -144,6 +145,7 @@ namespace icedb {
 						<< std::endl;
 				}
 			}
+
 			if (required->number_of_particle_constituents > 1 && this->particle_constituent_name.empty()) {
 				good = false;
 				if (out) (*out) << "number_of_particle_constituents > 1, so particle_constituent_name "
@@ -259,7 +261,7 @@ namespace icedb {
 			Expects(required->isValid(&(std::cerr)));
 			if (required->requiresOptionalPropertiesStruct()) Expects(optional);
 			if (optional) Expects(optional->isValid(required));
-			
+
 			Shape::Shape_Type res = std::make_unique<Shape_impl>(uid, newShapeLocation);
 			
 			// Write required attributes
@@ -270,7 +272,7 @@ namespace icedb {
 
 			std::unique_ptr<icedb::Tables::Table> tblPSEN;
 			{
-				tblPSEN = res->createTable<int64_t>("particle_scattering_element_number",
+				tblPSEN = res->createTable<uint64_t>("particle_scattering_element_number",
 				{ static_cast<size_t>(required->number_of_particle_scattering_elements) });
 				bool added = false;
 				if (optional) {
@@ -281,7 +283,7 @@ namespace icedb {
 				}
 				if (!added) {
 					// Create "dummy" element numbers and write.
-					std::vector<int64_t> dummyPSENs(required->number_of_particle_scattering_elements);
+					std::vector<uint64_t> dummyPSENs(required->number_of_particle_scattering_elements);
 					for (size_t i = 0; i < required->number_of_particle_scattering_elements; ++i)
 						dummyPSENs[i] = i + 1;
 					tblPSEN->writeAll(dummyPSENs);


### PR DESCRIPTION
Fixes #12.

Shape coordinates can either be stored as floats or as int32_t.

TODO: Make sure that Eugene's code works with this convention.
TODO: Add typedefs and document the variable types more thoroughly.