### PR TITLE
Shape filename match fixes

### DIFF
--- a/apps/3d_structures_singlethreaded/README.md
+++ b/apps/3d_structures_singlethreaded/README.md
@@ -9,14 +9,22 @@ shapes.
 
 To import a file or folder (shape.dat, shape.nc) into a database (shape.hdf5):
 ```
-3d_structures_example --from shape.dat --to shape.hdf5
+3d_structures_singlethreaded --from shape.dat --to shape.hdf5
 ```
 
 ## Program options
 
-| Option | Input type | Description |
-| -----  | ---------- | ----------- |
-| from   | string     | Path where shapes are read from. For this simple example, this must be a file containing a single shape. |
-| to     | string     | Path where shapes are written to. |
-| resolution | float  | The lattice spacing (in um). |
-| from-format | string | The format of the input files. This needs to be specified when the inputs are NetCDF or HDF5 files, as there are multiple conventions for these files that cannot be easily autodetected. |
+| Group | Option | Input type | Description |
+| ----- | -----  | ---------- | ----------- |
+| I/O   | from   | strings     | Path where shapes are read from. This may be a list of folders and files. If a directory is encountered, then it is recursively searched for shapes. The recursive search behavior is controlled by the from-matching-extensions option. |
+| I/O   | from-format | string | The format of the input files. The format of the input files. This needs to be specified when the inputs are NetCDF or HDF5 files, as there are multiple conventions for these files that cannot be easily autodetected. Options: text, psu. |
+| I/O   | from-nosearch | boolean | Set this option if you want to read in a set of files whose paths are exactly specified on the command line. This option allows for the finest control of input file selection. |
+| I/O   | from-matching-extensions | strings | Use this to override the extensions of files to match (e.g. .adda .shp) when searching for valid shapes in directories specified in --from. |
+| I/O   | to     | string     | Path where shapes are written to. |
+| I/O   | db-path | string    | The group within the HDF5 database where the new data is written to. |
+| I/O   | create | None | Create the output database if it does not exist. If it does, then exit without writing. |
+| I/O   | truncate | None | Overwrite the output file. If not specified, then an already-existing output file is appended to. |
+| Metadata | resolution | float  | The lattice spacing (in um). |
+| Metadata | author | string | Name(s) of the person/group who generated the shape. |
+| Metadata | contact-information | string | Affiliation, Contact information including email of the person/group who generated the scattering data. |
+| Metadata | scattering-method | string | Method applied to the shape to calculate the scattering properties. | 

--- a/apps/3d_structures_singlethreaded/shapes-main.cpp
+++ b/apps/3d_structures_singlethreaded/shapes-main.cpp
@@ -6,8 +6,8 @@
  *
  * Here's how the program works:
  * 1. Read the user options.
- * 2. Read the shape.
- * 3. Write the shape.
+ * 2. Find valid shape files from the provided paths.
+ * 2. Read each shape, then write to the output file.
 **/
 
 #include <icedb/defs.h>
@@ -43,16 +43,25 @@ int main(int argc, char** argv) {
 		// Read program options
 
 		namespace po = boost::program_options;
-		po::options_description desc("General options"), mdata("Shape metadata");
+		po::options_description desc("General options"), mdata("Shape metadata"), input_matching("Input options");
 		desc.add_options()
 			("help,h", "produce help message")
-			("from", po::value<vector<string> >()->multitoken(), "The paths where shapes are read from")
 			("to", po::value<string>(), "The path where the shape is written to")
 			("db-path", po::value<string>()->default_value("shape"), "The path within the database to write to")
 			("create", "Create the output database if it does not exist")
 			("resolution", po::value<float>(), "Lattice spacing for the shape, in um")
 			("truncate", "Instead of opening existing output files in read-write mode, truncate them.")
+			;
+		input_matching.add_options()
+			("from", po::value<vector<string> >()->multitoken(), "The paths where shapes are read from")
 			("from-format", po::value<string>()->default_value("text"), "The format of the input files. Options: text, psu.")
+			("from-nosearch", po::value<bool>()->default_value(false),
+				"Set this option if you want to read in a set of files whose paths are exactly specified on the command line. "
+				"This option allows for far greater control of input file selection.")
+			("from-matching-extensions", po::value<vector<string> >()->multitoken(), 
+				"Specify the extensions of files to match (e.g. .adda .shp) when searching for valid shapes. If not "
+				"specified, then the defaults are: "
+				"(text: .dat, .shp, .txt, .shape) (psu: .nc).")
 			;
 		mdata.add_options()
 			("author", po::value<string>(), "Name(s) of the person/group who generated the shape.")
@@ -60,6 +69,7 @@ int main(int argc, char** argv) {
 			("scattering-method", po::value<string>(), "Method applied to the shape to calculate the scattering properties.")
 			;
 		desc.add(mdata);
+		desc.add(input_matching);
 		po::variables_map vm;
 		po::store(po::command_line_parser(argc, argv).options(desc).run(), vm);
 		po::notify(vm);
@@ -83,6 +93,10 @@ int main(int argc, char** argv) {
 		string dbpath = vm["db-path"].as<string>();
 		if (vm.count("resolution")) resolution_um = vm["resolution"].as<float>();
 		string informat = vm["from-format"].as<string>();
+		bool from_nosearch = vm["from-nosearch"].as<bool>();
+		vector<string> vCustomFileFormats = vm["from-matching-extensions"].as<vector<string>>();
+		std::set<sfs::path> customFileFormats;
+		for (const auto &c : vCustomFileFormats) customFileFormats.insert(c);
 
 		// Metadata
 		string sAuthor, sContact, sScattMeth;
@@ -109,11 +123,18 @@ int main(int argc, char** argv) {
 		std::cout << "Creating base group " << dbpath << std::endl;
 		basegrp = db->createGroupStructure(dbpath);
 	
-		// Changes start here
 		for (const auto &sFromRaw : vsFromRaw)
 		{
 			sfs::path pFromRaw(sFromRaw);
-			auto files = icedb::fs::impl::collectDatasetFiles(pFromRaw, file_formats.at(informat));
+			icedb::fs::impl::CollectedFilesRet_Type files;
+			if (from_nosearch)
+				files.push_back(std::pair<sfs::path, std::string>(sfs::path(sFromRaw), sFromRaw));
+			else {
+				if (customFileFormats.size())
+					files = icedb::fs::impl::collectDatasetFiles(pFromRaw, customFileFormats);
+				else
+					files = icedb::fs::impl::collectDatasetFiles(pFromRaw, file_formats.at(informat));
+			}
 			for (const auto &f : files)
 			{
 				// Reading the shape from the text file

--- a/apps/3d_structures_singlethreaded/shapes-main.cpp
+++ b/apps/3d_structures_singlethreaded/shapes-main.cpp
@@ -27,7 +27,7 @@
 
 // A list of valid shapefile output formats
 const std::map<std::string, std::set<sfs::path> > file_formats = {
-	{"text", {".dat", ".shp", ".txt", ".shape"} },
+	{"text", {".dat", ".shp", ".txt", ".shape", ".geom", ".adda"} },
 	{"icedb", {".hdf5", ".nc", ".h5", ".cdf", ".hdf"} },
 	{"psu", {".nc"}}
 };

--- a/lib/icedb/fs_backend.hpp
+++ b/lib/icedb/fs_backend.hpp
@@ -43,11 +43,15 @@ namespace icedb {
 
 			/// File path, relative mount point
 			typedef std::vector<std::pair<sfs::path, std::string> > CollectedFilesRet_Type;
-			/// Find all files under the base location that have matching extensions.
+			/// \brief Find all files under the base location that have matching extensions.
 			/// Used to collect files for reading.
+			/// \param base is the base path
+			/// \param fileExtensionsToMatch is a list of file extensions that are matched
+			/// \param MatchOnAnySingleFile is a flag that forces a match if a single file is specified.
 			CollectedFilesRet_Type collectDatasetFiles(
 				const sfs::path &base,
-				const ExtensionsMatching_Type &fileExtensionsToMatch = common_hdf5_extensions);
+				const ExtensionsMatching_Type &fileExtensionsToMatch = common_hdf5_extensions,
+				bool MatchOnAnySingleFile = true);
 
 			/// Like resolveSymLinks, but throw if the resulting path does not exist.
 			sfs::path resolveSymlinkPathandForceExists(const std::string &location);

--- a/lib/src/fs_backend.cpp
+++ b/lib/src/fs_backend.cpp
@@ -25,7 +25,8 @@ namespace icedb {
 
 			CollectedFilesRet_Type collectDatasetFiles(
 				const sfs::path &base,
-				const ExtensionsMatching_Type &valid_extensions)
+				const ExtensionsMatching_Type &valid_extensions,
+				bool MatchOnAnySingleFile)
 			{
 				std::string sBase = base.string();
 				std::replace(sBase.begin(), sBase.end(), '\\', '/');
@@ -33,7 +34,7 @@ namespace icedb {
 				std::vector<std::pair<sfs::path, std::string> > res;
 				auto sbase = resolveSymlinkPathandForceExists(base.string());
 				if (sfs::is_regular_file(sbase)) {
-					if (valid_extensions.count(base.extension()) > 0) {
+					if (valid_extensions.count(base.extension()) > 0 || MatchOnAnySingleFile) {
 						res.push_back(std::pair<sfs::path, std::string>(sbase, "/"));
 					}
 				}


### PR DESCRIPTION
These commits fix #24 for the 3d_structures-singlethreaded program. 

The program does not rely on shell expansion (i.e. *.shp), by design, because this is inconsistent across different shells and Linux distributions. Also, some shells limit the maximum command line length.

The program instead attempts to read every possible shape file under the paths listed in the --from option. The detection of these shapes depends on the file extension. Program options have been added to allow you to fine-tune this matching. "3d_structures-singlethreaded -h" will list these options.

.geom and .adda files are now automatically detected as candidate shape files.